### PR TITLE
feat: Template derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
  "venial",
 ]
 

--- a/helper_macros/Cargo.toml
+++ b/helper_macros/Cargo.toml
@@ -15,3 +15,4 @@ proc-macro = true
 proc-macro2 = "1"
 quote = "1"
 venial = "0.6"
+syn = "2.0"

--- a/helper_macros/src/lib.rs
+++ b/helper_macros/src/lib.rs
@@ -1,5 +1,10 @@
+use core::panic;
+
 use function::gen_function;
+use proc_macro::TokenStream;
+use syn::{parse_macro_input, Data, DeriveInput, Fields};
 use venial::{parse_item, Error, Item};
+use quote::quote;
 
 mod function;
 
@@ -16,5 +21,50 @@ pub fn function(
 
     func.and_then(gen_function)
         .unwrap_or_else(|e| e.to_compile_error())
+        .into()
+}
+
+/// This macro implements a way to convert structs into `SrTemplate`
+/// instances.
+///
+/// The macro internally implements an anonymous function called
+/// `template()` which converts the current struct into an instance
+/// of `SrTemplate` using the struct fields and the instance values.
+#[proc_macro_derive(Template)]
+pub fn template(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = input.ident;
+
+    let fields = if let Data::Struct(s) = input.data {
+        if let Fields::Named(fields) = s.fields {
+            fields.named
+                .into_iter()
+                .map(|f| f.ident.unwrap())
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        }
+    } else {
+        panic!("This macro can only be applied to structs.")
+    };
+
+    let field_adds = fields
+        .iter()
+        .map(|field| {
+            quote! {
+                ctx.add_variable(stringify!(#field), &self.#field);
+            }
+        });
+
+    quote! {
+        impl #name {
+            pub fn template(&self) -> srtemplate::SrTemplate {
+                let mut ctx = srtempalte::SrTemplate::default();
+                #(#field_adds)*
+
+                ctx
+            }
+        }
+    }
         .into()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub use error::Error;
 pub use template::{function, Function, SrTemplate};
 
 #[cfg(feature = "macros")]
-pub use helper_macros::function;
+pub use helper_macros::{function, Template};
 
 /// The `prelude` module re-exports common items for easier use of `SrTemplate`.
 pub mod prelude {


### PR DESCRIPTION
This PR adds a macro that anonymously implements `template()` for the deriving struct, this dynamically obtains an instance of `SrTemplate` so it can be integrated with serialized and typed structs.

The expected usage is the following

```rust
#[derive(Template)]
struct Person {
    name: String,
    age: u32
}

fn main() {
   let person = Person { name: "Memw".to_string(), age: 19 };
   let ctx = person.template();

   let template = "This person's name is {{ name }} and it's age is {{ age }}";
   println!("Rendered: {}", ctx.render(template).unwrap());
}
```

I was looking a way to implement tests for this thing, so I'll mark this PR as WIP for the moment.